### PR TITLE
Explore using clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ web-audio-api = "0.24.0"
 anyhow = "1.0.66"
 cpal = "0.14.1"
 crossbeam = "0.8.2"
+clap = { version = "4.0.26", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Mainly because once I had the idea, I couldn't unthink it... Also I wanted to be
 * `smiley [manic|cynic]` Constrains samples to stay positive. Results in very mild distortion.
 * `speedy [x]` Changes the speed by factor `x`. For example, `speedy 0.5` halves the speed.
 
----
+<!-- ---
 
 #### `previous module`
 
@@ -56,7 +56,7 @@ Arguments:
 
 #### `next module`
 
-blubb
+blubb -->
 
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -39,17 +39,24 @@ Mainly because once I had the idea, I couldn't unthink it... Also I wanted to be
 
 ---
 
-- `previous module`:
-- `extremely`:
-    ```
-    Linearly interpolate each sample toward +/-1
+#### `previous module`
 
-    Usage: extremely [T]
+bla
 
-    Arguments:
-    [T]  How strongly to interpolate samples toward +/- 1 [default: 1]
-    ```
-- `next module`:
+#### `extremely`
+
+```
+Linearly interpolate each sample toward +/-1
+
+Usage: extremely [T]
+
+Arguments:
+[T]  How strongly to interpolate samples toward +/- 1 [default: 1]
+```
+
+#### `next module`
+
+blubb
 
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -35,7 +35,22 @@ Mainly because once I had the idea, I couldn't unthink it... Also I wanted to be
 * `smashy` Can't quite explain what this does, it sounds like extreme compression being applied in an unpredictable manner. Takes `stdin` sends via `sdout`.
 * `smoothy [n]` Average each sample with the last `n` samples.
 * `smiley [manic|cynic]` Constrains samples to stay positive. Results in very mild distortion.
-* `speedy [x]` Changes the speed by factor `x`. For example, `speedy 0.5` halves the speed. 
+* `speedy [x]` Changes the speed by factor `x`. For example, `speedy 0.5` halves the speed.
+
+---
+
+- `previous module`:
+- `extremely`:
+    ```
+    Linearly interpolate each sample toward +/-1
+
+    Usage: extremely [T]
+
+    Arguments:
+    [T]  How strongly to interpolate samples toward +/- 1 [default: 1]
+    ```
+- `next module`:
+
 
 ## Contribute
 

--- a/src/extremely.rs
+++ b/src/extremely.rs
@@ -1,20 +1,21 @@
-use std::env;
+use clap::Parser;
 
 use earwig::utils::{sample_loop, lerp};
 
-fn main() {
-    // Parse args or set defaults
-    let args: Vec<String> = env::args().collect();
+/// Linearly interpolate each sample toward +/-1
+#[derive(Parser, Debug)]
+struct Args {
+   /// How strongly to interpolate samples toward +/- 1.
+   #[arg(default_value_t = 1.0)]
+   t: f64,
+}
 
-    // How strongly to interpolate samples toward +/- 1.
-    let t: f64 = match args.get(1) {
-        Some(t) => t.parse().unwrap_or(1.0),
-        None => 1.0,
-    };
+fn main() {
+    let args = Args::parse();
 
     sample_loop![mut sample in {
         // Turn that boring sample into something more extreme!
-        sample = lerp(sample, sample.signum(), t);
+        sample = lerp(sample, sample.signum(), args.t);
 
         // print the sample to stdout
         println!("{sample}")


### PR DESCRIPTION
This is what clap-based modules would look like. How do you feel about giving these more verbose usage instructions in the list of modules?

I will refactor everything to use clap before merging this after we settle on a style (for the readme in particular). Right now I've taken the output of `extremely --help`, removed the windows-specific bits, and removed the `--help` option.

Compilation time hasn't been noticeably affected by deriving `Parser` for just a single module.

For reference, here is the output of `extremely --help` on my machine:

```
$ ../target/debug/extremely --help
Linearly interpolate each sample toward +/-1

Usage: extremely.exe [T]

Arguments:
  [T]  How strongly to interpolate samples toward +/- 1 [default: 1]

Options:
  -h, --help  Print help information
```